### PR TITLE
fix: update dependencies and closes #11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    id "com.github.ben-manes.versions" version "0.53.0"
+    id "se.patrikerdes.use-latest-versions" version "0.2.19"
 }
 
 repositories {
@@ -18,41 +20,41 @@ compileJava {
 
 
 dependencies {
-    api("org.testcontainers:testcontainers:1.17.6") {
+    api("org.testcontainers:testcontainers:2.0.2") {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
     }
-    api ("org.testcontainers:junit-jupiter:1.17.6") {
+    api ("org.testcontainers:junit-jupiter:1.21.3") {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
     }
 
-    implementation 'io.github.openfeign:feign-core:12.2'
-    implementation('io.github.openfeign:feign-jackson:12.2') {
+    implementation 'io.github.openfeign:feign-core:13.6'
+    implementation('io.github.openfeign:feign-jackson:13.6') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
     }
 
-    compileOnly 'com.bloxbean.cardano:cardano-client-lib:0.6.2'
-    compileOnly 'com.bloxbean.cardano:cardano-client-backend:0.6.2'
-    compileOnly 'com.bloxbean.cardano:cardano-client-backend-ogmios:0.6.2'
-    compileOnly 'com.bloxbean.cardano:cardano-client-backend-blockfrost:0.6.2'
+    compileOnly 'com.bloxbean.cardano:cardano-client-lib:0.7.1'
+    compileOnly 'com.bloxbean.cardano:cardano-client-backend:0.7.1'
+    compileOnly 'com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.1'
+    compileOnly 'com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.1'
 
     api 'org.assertj:assertj-core:3.24.2'
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.slf4j:slf4j-simple:2.0.7'
 
-    testImplementation 'com.bloxbean.cardano:cardano-client-lib:0.6.2'
-    testImplementation 'com.bloxbean.cardano:cardano-client-backend:0.6.2'
-    testImplementation 'com.bloxbean.cardano:cardano-client-backend-ogmios:0.6.2'
-    testImplementation 'com.bloxbean.cardano:cardano-client-backend-blockfrost:0.6.2'
+    testImplementation 'com.bloxbean.cardano:cardano-client-lib:0.7.1'
+    testImplementation 'com.bloxbean.cardano:cardano-client-backend:0.7.1'
+    testImplementation 'com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.1'
+    testImplementation 'com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.1'
 
-    testCompileOnly 'org.projectlombok:lombok:1.18.24'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    testCompileOnly 'org.projectlombok:lombok:1.18.42'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.42'
 }
 
 tasks.withType(Javadoc) {

--- a/src/test/java/com/bloxbean/cardano/yaci/test/YaciContainerTest.java
+++ b/src/test/java/com/bloxbean/cardano/yaci/test/YaciContainerTest.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.api.util.PolicyUtil;
 import com.bloxbean.cardano.client.backend.api.TransactionService;
 import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.client.function.Output;
@@ -27,13 +28,13 @@ import com.bloxbean.cardano.client.transaction.spec.Asset;
 import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
 import com.bloxbean.cardano.client.transaction.spec.Policy;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
-import com.bloxbean.cardano.client.util.PolicyUtil;
 import com.bloxbean.cardano.yaci.test.api.helper.YaciTestHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
@@ -45,19 +46,21 @@ import static com.bloxbean.cardano.yaci.test.api.Assertions.assertMe;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class YaciContainerTest {
-    private static String senderMnemonic = "flush together outer effort tenant photo waste distance rib grocery aunt broken weather arrow jungle debris finger flee casino doctor group echo baby near";
-    private static Account account = new Account(Networks.testnet(), senderMnemonic);
+    private static final String senderMnemonic = "flush together outer effort tenant photo waste distance rib grocery aunt broken weather arrow jungle debris finger flee casino doctor group echo baby near";
+    private static final Account account = Account.createFromMnemonic(Networks.testnet(), senderMnemonic);
     private static UtxoSupplier utxoSupplier;
     private static ProtocolParamsSupplier protocolParamSupplier;
     private static TransactionService transactionService;
 
-    private static YaciCardanoContainer cardanoContainer = new YaciCardanoContainer();
+    private static final YaciCardanoContainer cardanoContainer = new YaciCardanoContainer();
 
-    private static YaciTestHelper testHelper = cardanoContainer.getTestHelper();
+    private static final YaciTestHelper testHelper = cardanoContainer.getTestHelper();
 
     @BeforeAll
-    static void setup() {
+    void setup() throws InterruptedException {
         if (!cardanoContainer.isRunning()) {
             cardanoContainer
                     .withInitialFunding(new Funding(account.baseAddress(), 20000))
@@ -68,9 +71,20 @@ public class YaciContainerTest {
             protocolParamSupplier = cardanoContainer.getProtocolParamsSupplier();
             transactionService = cardanoContainer.getTransactionService();
         }
+        log.info("Waiting for Yaci Store to be ready...");
+        List<Utxo> utxos = utxoSupplier.getAll(account.baseAddress());
+        int retries = 4;
+
+        while (utxos.size() == 0 || retries < 0) {
+            utxos = utxoSupplier.getAll(account.baseAddress());
+            retries--;
+            //noinspection BusyWait
+            Thread.sleep(2000);
+        }
     }
 
     @Test
+    @Order(1)
     void transfer_lovelace() throws Exception {
         String senderAddress = account.baseAddress();
         log.info("Sender address : " + senderAddress);
@@ -99,6 +113,7 @@ public class YaciContainerTest {
     }
 
     @Test
+    @Order(2)
     void mint_transfer_assets() throws Exception {
         String senderAddress = account.baseAddress();
         log.info("Sender address : " + senderAddress);
@@ -175,6 +190,7 @@ public class YaciContainerTest {
     }
 
     @Test
+    @Order(3)
     void transferTest() throws Exception {
         String senderAddress = account.baseAddress();
         log.info("Sender address : " + senderAddress);
@@ -196,47 +212,54 @@ public class YaciContainerTest {
         Result<String> result = transactionService.submitTransaction(signedTransaction.serialize());
         testHelper.waitForTransactionHash(result);
 
-        System.out.println(result);
-        assertThat(testHelper.lovelaceBalance(receiverAddress).get()).isEqualTo(adaToLovelace(2.1));
+        Optional<BigInteger> lovelaceBalance = testHelper.lovelaceBalance(receiverAddress);
+
+        assertThat(lovelaceBalance.isPresent()).isTrue();
+        assertThat(lovelaceBalance.get()).isEqualTo(adaToLovelace(2.1));
         assertThat(testHelper.amounts(receiverAddress)).hasSize(1);
     }
 
     @Test
+    @Order(4)
     void lockUnlockTest() throws Exception {
         String receiver = "addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c";
         String compiledCode = "590169010100323232323232323225333002323232323253330073370e900118049baa0011323232533300a3370e900018061baa005132533300f00116132533333301300116161616132533301130130031533300d3370e900018079baa004132533300e3371e6eb8c04cc044dd5004a4410d48656c6c6f2c20576f726c642100100114a06644646600200200644a66602a00229404c94ccc048cdc79bae301700200414a2266006006002602e0026eb0c048c04cc04cc04cc04cc04cc04cc04cc04cc040dd50051bae301230103754602460206ea801054cc03924012465787065637420536f6d6528446174756d207b206f776e6572207d29203d20646174756d001616375c0026020002601a6ea801458c038c03c008c034004c028dd50008b1805980600118050009805001180400098029baa001149854cc00d2411856616c696461746f722072657475726e65642066616c736500136565734ae7155ceaab9e5573eae855d12ba401";
 
         PlutusScript plutusScript = PlutusBlueprintUtil.getPlutusScriptFromCompiledCode(compiledCode, PlutusVersion.v3);
-        String scrtiptAddr = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
+        String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
 
         //create datum
-        PlutusData datum = ConstrPlutusData.of(0, BytesPlutusData.of(account.getBaseAddress().getPaymentCredentialHash().get()));
+        Optional<byte[]> paymentCredentialHash = account.getBaseAddress().getPaymentCredentialHash();
+        Assertions.assertTrue(paymentCredentialHash.isPresent());
+        PlutusData datum = ConstrPlutusData.of(0, BytesPlutusData.of(paymentCredentialHash.get()));
 
-        testHelper.lockFund(account, scrtiptAddr, List.of(Amount.ada(10)), datum);
+        testHelper.lockFund(account, scriptAddress, List.of(Amount.ada(10)), datum);
 
         Thread.sleep(2000);
 
         //Unlock
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(cardanoContainer.getBackendService());
 
-        Utxo scriptUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scrtiptAddr, datum).orElseThrow();
+        Utxo scriptUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, datum).orElseThrow();
 
         PlutusData redeemer = ConstrPlutusData.of(0, BytesPlutusData.of("Hello, World!"));
 
-        ScriptTx sctipTx = new ScriptTx()
+        ScriptTx scriptTx = new ScriptTx()
                 .collectFrom(scriptUtxo, redeemer)
                 .payToAddress(receiver, Amount.ada(10))
                 .attachSpendingValidator(plutusScript);
 
-        Result<String> result1 = quickTxBuilder.compose(sctipTx)
+        Result<String> result1 = quickTxBuilder.compose(scriptTx)
                 .feePayer(receiver)
                 .collateralPayer(account.baseAddress())
                 .withSigner(SignerProviders.signerFrom(account))
                 .withRequiredSigners(account.getBaseAddress())
                 .completeAndWait(System.out::println);
 
+        Optional<BigInteger> lovelaceBalance = testHelper.lovelaceBalance(receiver);
+        assertThat(lovelaceBalance.isPresent()).isTrue();
         assertThat(result1.isSuccessful()).isTrue();
-        assertThat(testHelper.lovelaceBalance(receiver).get()).isGreaterThanOrEqualTo(adaToLovelace(9));
+        assertThat(lovelaceBalance.get()).isGreaterThanOrEqualTo(adaToLovelace(9));
 
     }
 

--- a/src/test/java/com/bloxbean/cardano/yaci/test/api/UtxoListAssertTest.java
+++ b/src/test/java/com/bloxbean/cardano/yaci/test/api/UtxoListAssertTest.java
@@ -161,8 +161,7 @@ class UtxoListAssertTest {
                 ))
                 .build();
 
-        List<Utxo> utxos = List.of(utxo1, utxo2, utxo3);
-        return utxos;
+        return List.of(utxo1, utxo2, utxo3);
     }
 
     @NotNull
@@ -204,8 +203,7 @@ class UtxoListAssertTest {
                 ))
                 .inlineDatum(Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(new Datum2("John")).serializeToHex())
                 .build();
-        List<Utxo> utxos = List.of(utxo1, utxo2, utxo3, utxo4);
-        return utxos;
+        return List.of(utxo1, utxo2, utxo3, utxo4);
     }
 
     @Data

--- a/src/test/java/com/bloxbean/cardano/yaci/test/api/helper/TransactionHelperTest.java
+++ b/src/test/java/com/bloxbean/cardano/yaci/test/api/helper/TransactionHelperTest.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.test.api.helper;
 
 import com.bloxbean.cardano.client.account.Account;
 import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.model.Utxo;
 import com.bloxbean.cardano.client.api.util.AssetUtil;
@@ -17,9 +18,7 @@ import com.bloxbean.cardano.client.transaction.spec.Value;
 import com.bloxbean.cardano.yaci.test.Funding;
 import com.bloxbean.cardano.yaci.test.YaciCardanoContainer;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -31,24 +30,38 @@ import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
 import static com.bloxbean.cardano.yaci.test.api.Assertions.assertMe;
 
 @Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TransactionHelperTest {
-    private static String senderMnemonic = "flush together outer effort tenant photo waste distance rib grocery aunt broken weather arrow jungle debris finger flee casino doctor group echo baby near";
-    private static Account account = new Account(Networks.testnet(), senderMnemonic);
+    private static final String senderMnemonic = "flush together outer effort tenant photo waste distance rib grocery aunt broken weather arrow jungle debris finger flee casino doctor group echo baby near";
+    private static final Account account = Account.createFromMnemonic(Networks.testnet(), senderMnemonic);
 
-    private static YaciCardanoContainer cardanoContainer = new YaciCardanoContainer();
-    private static YaciTestHelper testHelper = cardanoContainer.getTestHelper();
+    private static final YaciCardanoContainer cardanoContainer = new YaciCardanoContainer();
+    private static final YaciTestHelper testHelper = cardanoContainer.getTestHelper();
 
     @BeforeAll
-    static void setup() {
+    void setup() throws InterruptedException {
         if (!cardanoContainer.isRunning()) {
             cardanoContainer
                     .withInitialFunding(new Funding(account.baseAddress(), 20000))
                     .withLogConsumer(outputFrame -> log.info(outputFrame.getUtf8String()))
                     .start();
+            UtxoSupplier utxoSupplier = cardanoContainer.getUtxoSupplier();
+            log.info("Waiting for Yaci Store to be ready...");
+            List<Utxo> utxos = utxoSupplier.getAll(account.baseAddress());
+            int retries = 4;
+
+            while (utxos.size() == 0 || retries < 0) {
+                utxos = utxoSupplier.getAll(account.baseAddress());
+                retries--;
+                //noinspection BusyWait
+                Thread.sleep(2000);
+            }
         }
     }
 
     @Test
+    @Order(1)
     void transferAda() {
         String receiver = "addr_test1qqp6l53xshenlc939a0q74rd09e7dva8lke0fvs3a7ld5f7y7h8vnukjnluapukncvvpxvjgg4nlwu34w3ywvzngw99sy2rpy3";
         testHelper.transferAda(receiver, 10000);
@@ -57,18 +70,25 @@ class TransactionHelperTest {
     }
 
     @Test
+    @Order(2)
     void mintToken() throws Exception {
         String receiver = "addr_test1qqp6l53xshenlc939a0q74rd09e7dva8lke0fvs3a7ld5f7y7h8vnukjnluapukncvvpxvjgg4nlwu34w3ywvzngw99sy2rpy3";
-        Policy policy = testHelper.mintToken(receiver, "TestToken", 10000).get();
+        Optional<Policy> optionalPolicy = testHelper.mintToken(receiver, "TestToken", 10000);
+        Assertions.assertTrue(optionalPolicy.isPresent());
+        Policy policy = optionalPolicy.get();
 
         assertMe(cardanoContainer).hasAssetBalance(receiver, policy.getPolicyId(), "TestToken", BigInteger.valueOf(10000));
     }
 
     @Test
+    @Order(3)
     void lockFund_withAmounts() throws Exception {
         Account account = new Account(Networks.testnet());
         testHelper.transferAda(account.baseAddress(), 100);
-        Policy policy = testHelper.mintToken(account.baseAddress(), "TestToken", 10000).get();
+        Optional<Policy> optionalPolicy = testHelper.mintToken(account.baseAddress(), "TestToken", 10000);
+
+        Assertions.assertTrue(optionalPolicy.isPresent());
+        Policy policy = optionalPolicy.get();
         PlutusV1Script plutusScript = PlutusV1Script.builder()
                 .type("PlutusScriptV1")
                 .cborHex("4e4d01000033222220051200120011")
@@ -79,7 +99,7 @@ class TransactionHelperTest {
                 new Amount(LOVELACE, adaToLovelace(4)), new Amount(unit, BigInteger.valueOf(50)));
 
         PlutusData plutusData = BigIntPlutusData.of(400);
-        Optional<String> txId = testHelper.lockFund(account, plutusScript, amounts, plutusData);
+        testHelper.lockFund(account, plutusScript, amounts, plutusData);
 
         assertMe(cardanoContainer).utxos(scriptAddress).hasLovelaceBalance(balance -> balance.compareTo(adaToLovelace(4)) >= 0);
         assertMe(cardanoContainer).utxos(scriptAddress).hasAssetBalance(policy.getPolicyId(), "TestToken", BigInteger.valueOf(50));
@@ -87,6 +107,7 @@ class TransactionHelperTest {
     }
 
     @Test
+    @Order(4)
     void lockFund_withValue() throws Exception {
         Account account = new Account(Networks.testnet());
         PlutusV2Script plutusScript = PlutusV2Script.builder()
@@ -96,22 +117,28 @@ class TransactionHelperTest {
         String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
 
         testHelper.transferAda(account.baseAddress(), 100);
-        Policy policy1 = testHelper.mintToken(account.baseAddress(), "TestToken1", 10000).get();
-        Policy policy2 = testHelper.mintToken(account.baseAddress(), "TestToken2", 5000).get();
+
+        Optional<Policy> optionalPolicy1 = testHelper.mintToken(account.baseAddress(), "TestToken1", 10000);
+        Optional<Policy> optionalPolicy2 = testHelper.mintToken(account.baseAddress(), "TestToken2", 5000);
+        Assertions.assertTrue(optionalPolicy1.isPresent());
+        Assertions.assertTrue(optionalPolicy2.isPresent());
+
+        Policy policy1 = optionalPolicy1.get();
+        Policy policy2 = optionalPolicy2.get();
 
         Value value = Value.builder()
                 .coin(adaToLovelace(4))
                 .multiAssets(Arrays.asList(
-                        new MultiAsset(policy1.getPolicyId(), Arrays.asList(
+                        new MultiAsset(policy1.getPolicyId(), List.of(
                                 new Asset("TestToken1", BigInteger.valueOf(60))
                         )),
-                        new MultiAsset(policy2.getPolicyId(), Arrays.asList(
+                        new MultiAsset(policy2.getPolicyId(), List.of(
                                 new Asset("TestToken2", BigInteger.valueOf(50))
                         ))
                 )).build();
 
         PlutusData plutusData = BigIntPlutusData.of(400);
-        Optional<String> txId = testHelper.lockFund(account, plutusScript, value, plutusData);
+        testHelper.lockFund(account, plutusScript, value, plutusData);
 
         assertMe(cardanoContainer).utxos(scriptAddress).hasLovelaceBalance(balance -> balance.compareTo(adaToLovelace(4)) >= 0);
         assertMe(cardanoContainer).utxos(scriptAddress).hasAssetBalance(policy1.getPolicyId(), "TestToken1", BigInteger.valueOf(60));
@@ -120,8 +147,11 @@ class TransactionHelperTest {
     }
 
     @Test
+    @Order(5)
     void lockFund_fromFaucetAcc_withAmounts() throws Exception {
-        Policy policy = testHelper.mintToken("FaucetToken", 40000).get();
+        Optional<Policy> optionalPolicy = testHelper.mintToken("FaucetToken", 40000);
+        Assertions.assertTrue(optionalPolicy.isPresent());
+        Policy policy = optionalPolicy.get();
         PlutusV1Script plutusScript = PlutusV1Script.builder()
                 .type("PlutusScriptV1")
                 .cborHex("4e4d01000033222220051200120011")
@@ -132,7 +162,7 @@ class TransactionHelperTest {
                 new Amount(LOVELACE, adaToLovelace(4)), new Amount(unit, BigInteger.valueOf(50)));
 
         PlutusData plutusData = BigIntPlutusData.of(900);
-        Optional<String> txId = testHelper.lockFund(plutusScript, amounts, plutusData);
+        testHelper.lockFund(plutusScript, amounts, plutusData);
 
         assertMe(cardanoContainer).utxos(scriptAddress).hasLovelaceBalance(balance -> balance.compareTo(adaToLovelace(4)) >= 0);
         assertMe(cardanoContainer).utxos(scriptAddress).hasAssetBalance(policy.getPolicyId(), "FaucetToken", BigInteger.valueOf(50));
@@ -140,6 +170,7 @@ class TransactionHelperTest {
     }
 
     @Test
+    @Order(6)
     void lockFund_fromFaucetAcc_withValue() throws Exception {
         PlutusV2Script plutusScript = PlutusV2Script.builder()
                 .type("PlutusScriptV2")
@@ -147,22 +178,28 @@ class TransactionHelperTest {
                 .build();
         String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
 
-        Policy policy1 = testHelper.mintToken("FaucetToken1", 10000).get();
-        Policy policy2 = testHelper.mintToken("FaucetToken2", 5000).get();
+        Optional<Policy> optionalPolicy1 = testHelper.mintToken("FaucetToken1", 10000);
+        Optional<Policy> optionalPolicy2 = testHelper.mintToken("FaucetToken2", 5000);
+
+        Assertions.assertTrue(optionalPolicy1.isPresent());
+        Assertions.assertTrue(optionalPolicy2.isPresent());
+
+        Policy policy1 = optionalPolicy1.get();
+        Policy policy2 = optionalPolicy2.get();
 
         Value value = Value.builder()
                 .coin(adaToLovelace(4))
                 .multiAssets(Arrays.asList(
-                        new MultiAsset(policy1.getPolicyId(), Arrays.asList(
+                        new MultiAsset(policy1.getPolicyId(), List.of(
                                 new Asset("FaucetToken1", BigInteger.valueOf(60))
                         )),
-                        new MultiAsset(policy2.getPolicyId(), Arrays.asList(
+                        new MultiAsset(policy2.getPolicyId(), List.of(
                                 new Asset("FaucetToken2", BigInteger.valueOf(50))
                         ))
                 )).build();
 
         PlutusData plutusData = BigIntPlutusData.of(400);
-        Optional<String> txId = testHelper.lockFund(plutusScript, value, plutusData);
+        testHelper.lockFund(plutusScript, value, plutusData);
 
         assertMe(cardanoContainer).utxos(scriptAddress).hasLovelaceBalance(balance -> balance.compareTo(adaToLovelace(4)) >= 0);
         assertMe(cardanoContainer).utxos(scriptAddress).hasAssetBalance(policy1.getPolicyId(), "FaucetToken1", BigInteger.valueOf(60));
@@ -171,6 +208,7 @@ class TransactionHelperTest {
     }
 
     @Test
+    @Order(7)
     void createReferenceScript() {
         PlutusV2Script plutusScript = PlutusV2Script.builder()
                 .type("PlutusScriptV2")
@@ -178,6 +216,7 @@ class TransactionHelperTest {
                 .build();
 
         Optional<Utxo> utxo = testHelper.createReferenceScriptTx(plutusScript, 3);
+        Assertions.assertTrue(utxo.isPresent());
         assertMe(utxo.get()).containsReferenceScript(plutusScript);
     }
 


### PR DESCRIPTION
This pull request **bumps the dependency versions to fix #11**  and makes the test suite more deterministic by enforcing test execution order, and improving assertions. The main themes are improved test initialization/waiting logic, better assertion practices, and code consistency.

**Test Initialization and Reliability Improvements:**
- Added logic to wait for UTXOs to be available before running tests in `OgmiosYaciContainerTest`, `YaciContainerTest`, and `TransactionHelperTest`, ensuring tests only start when the blockchain backend is ready. This prevents race conditions and flaky tests. [[1]](diffhunk://#diff-bf5c4c0dfc3f34584fa498a2f39b9dd2e9790f216306f3a6a3c533cda3da028aR62-R75) [[2]](diffhunk://#diff-24578aed0e57b4fce5178af7becb58aae14a037c9a4ff168cfdeafbbd3890deaR74-R87) [[3]](diffhunk://#diff-a1c42c6f38c4f46c7dcba8dd926e8f25e436a2566fdeee56f7a9d1320ba3595dR33-R64)
- Changed test classes to use `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` and `@TestMethodOrder(MethodOrderer.OrderAnnotation.class)` for more predictable test execution and easier resource management. [[1]](diffhunk://#diff-bf5c4c0dfc3f34584fa498a2f39b9dd2e9790f216306f3a6a3c533cda3da028aR37-R50) [[2]](diffhunk://#diff-24578aed0e57b4fce5178af7becb58aae14a037c9a4ff168cfdeafbbd3890deaR49-R63) [[3]](diffhunk://#diff-a1c42c6f38c4f46c7dcba8dd926e8f25e436a2566fdeee56f7a9d1320ba3595dR33-R64)

**Assertion and Test Robustness:**
- Improved assertions for balance checks by verifying the presence of values returned from `Optional` before asserting their contents, reducing the risk of `NoSuchElementException` in tests. [[1]](diffhunk://#diff-bf5c4c0dfc3f34584fa498a2f39b9dd2e9790f216306f3a6a3c533cda3da028aL189-R207) [[2]](diffhunk://#diff-24578aed0e57b4fce5178af7becb58aae14a037c9a4ff168cfdeafbbd3890deaL199-R262)
- Updated minting tests to assert that the minted policy is present before proceeding, improving test reliability.

**Code Consistency and Cleanup:**
- Replaced mutable variables with `final` where appropriate and updated account creation to use `Account.createFromMnemonic` for consistency. [[1]](diffhunk://#diff-bf5c4c0dfc3f34584fa498a2f39b9dd2e9790f216306f3a6a3c533cda3da028aR37-R50) [[2]](diffhunk://#diff-24578aed0e57b4fce5178af7becb58aae14a037c9a4ff168cfdeafbbd3890deaR49-R63) [[3]](diffhunk://#diff-a1c42c6f38c4f46c7dcba8dd926e8f25e436a2566fdeee56f7a9d1320ba3595dR33-R64)
- Simplified return statements in helper methods by returning the result of `List.of(...)` directly. [[1]](diffhunk://#diff-ab4b964bed5e60ca7bd17a20457c5f70bcf470880434fb88e3488594497d25e3L164-R164) [[2]](diffhunk://#diff-ab4b964bed5e60ca7bd17a20457c5f70bcf470880434fb88e3488594497d25e3L207-R206)
- Minor naming and typo corrections for clarity in test code, such as fixing variable names and method calls.
